### PR TITLE
MvcBuildViews Workaround

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,8 +66,9 @@ jobs:
     - name: build proj
       if: ${{ matrix.language == 'csharp' }}
       run: |
-         nuget restore Orchard.proj
-         msbuild Orchard.proj
+         #nuget restore Orchard.proj
+         #msbuild Orchard.proj
+         .\ClickToBuild.cmd
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,8 +66,8 @@ jobs:
     - name: build proj
       if: ${{ matrix.language == 'csharp' }}
       run: |
-         nuget restore ./src/Orchard.proj
-         msbuild ./src/Orchard.proj
+         nuget restore Orchard.proj
+         msbuild Orchard.proj
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'csharp', 'javascript' ]
+        language: [ 'csharp', 'javascript' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
@@ -46,18 +46,28 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+  
+    - name: Setup NuGet.exe for use with actions
+      if: ${{ matrix.language == 'csharp' }}
+      uses: NuGet/setup-nuget@v1.1.1
 
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
+    - name: setup-msbuild
+      if: ${{ matrix.language == 'csharp' }}
+      uses: microsoft/setup-msbuild@v1.3.1
+
+    - name: build proj
+      if: ${{ matrix.language == 'csharp' }}
+      run: |
+         nuget restore ./src/Orchard.proj
+         msbuild ./src/Orchard.proj
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
```
2023-04-01T19:16:23.8949650Z     75>D:\a\Orchard\Orchard\src\Orchard.Web\Modules\Orchard.Glimpse\web.config(38): error ASPCONFIG: Could not load file or assembly 'System.Web.Mvc, Version=5.2.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040) [D:\a\Orchard\Orchard\src\Orchard.Web\Modules\Orchard.Glimpse\Orchard.Glimpse.csproj]
```

See discussion: https://github.com/OrchardCMS/Orchard/issues/7713